### PR TITLE
Fix Cloudinary auth encoding

### DIFF
--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -11,9 +11,9 @@ const seed = async () => {
           "Content-Type": "application/json",
           Authorization:
             "Basic " +
-            btoa(
+            Buffer.from(
               `${process.env.CLOUDINARY_API_KEY}:${process.env.CLOUDINARY_API_SECRET}`
-            ),
+            ).toString("base64"),
         },
       }
     );


### PR DESCRIPTION
## Summary
- fix authorization header in `lib/seed.ts`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f3f8161c8832e892f19ee7c2d7a7a